### PR TITLE
README: remove double )) in the config example

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,10 +24,10 @@ It depends on the following tools:
 (setq jmail-top-maildir "~/.cache/mails")
 
 ;; mbsync config file
-(setq jmail-sync-config-file "~/.mbsyncrc"))
+(setq jmail-sync-config-file "~/.mbsyncrc")
 
 ;; msmtp config file
-(setq jmail-smtp-config-file "~/.msmtprc"))
+(setq jmail-smtp-config-file "~/.msmtprc")
 
 ;; queries
 (setq jmail-queries '(("Custom" . (("Starred" . "flag:flagged")))


### PR DESCRIPTION
Some (setq) expressions have too much parentheses at the right,
resulting in evaluation errors when we attempt to load the example config.

Fix it by removing these additional parentheses.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>