### PR TITLE
view: derive from message-mode instead of text mode

### DIFF
--- a/jmail-view.el
+++ b/jmail-view.el
@@ -44,7 +44,7 @@
     map)
   "Keymap for `jmail-view-mode'")
 
-(define-derived-mode jmail-view-mode text-mode
+(define-derived-mode jmail-view-mode message-mode
   "jmail view"
   (toggle-read-only t))
 


### PR DESCRIPTION
By default, jmail-view-mode derives from text-mode.

Because of this, we don't have any color highlighting in
jmail-view-mode.

Derive from message-mode in order to use fonts such as
message-header-cc and message-header-subject

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>